### PR TITLE
Race condition in fs refs iterator when refs are packed by another process.

### DIFF
--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -483,7 +483,6 @@ static int iter_load_loose_paths(refdb_fs_backend *backend, refdb_fs_iter *iter)
 
 	while (!error && !git_iterator_advance(&entry, fsit)) {
 		const char *ref_name;
-		struct packref *ref;
 		char *ref_dup;
 
 		git_buf_truncate(&path, strlen(GIT_REFS_DIR));
@@ -493,12 +492,6 @@ static int iter_load_loose_paths(refdb_fs_backend *backend, refdb_fs_iter *iter)
 		if (git__suffixcmp(ref_name, ".lock") == 0 ||
 			(iter->glob && p_fnmatch(iter->glob, ref_name, 0) != 0))
 			continue;
-
-		git_sortedcache_rlock(backend->refcache);
-		ref = git_sortedcache_lookup(backend->refcache, ref_name);
-		if (ref)
-			ref->flags |= PACKREF_SHADOWED;
-		git_sortedcache_runlock(backend->refcache);
 
 		ref_dup = git_pool_strdup(&iter->pool, ref_name);
 		if (!ref_dup)
@@ -511,6 +504,21 @@ static int iter_load_loose_paths(refdb_fs_backend *backend, refdb_fs_iter *iter)
 	git_buf_free(&path);
 
 	return error;
+}
+
+static void iter_shadow_packed_refs(refdb_fs_backend *backend, refdb_fs_iter *iter)
+{
+	struct packref *ref;
+
+	while (iter->loose_pos < iter->loose.length) {
+		const char *path = git_vector_get(&iter->loose, iter->loose_pos++);
+		git_sortedcache_rlock(backend->refcache);
+		ref = git_sortedcache_lookup(backend->refcache, path);
+		if (ref)
+			ref->flags |= PACKREF_SHADOWED;
+		git_sortedcache_runlock(backend->refcache);
+	}
+	iter->loose_pos = 0;
 }
 
 static int refdb_fs_backend__iterator_next(
@@ -599,8 +607,6 @@ static int refdb_fs_backend__iterator(
 
 	assert(backend);
 
-	if (packed_reload(backend) < 0)
-		return -1;
 
 	iter = git__calloc(1, sizeof(refdb_fs_iter));
 	GITERR_CHECK_ALLOC(iter);
@@ -617,8 +623,17 @@ static int refdb_fs_backend__iterator(
 	iter->parent.next_name = refdb_fs_backend__iterator_next_name;
 	iter->parent.free = refdb_fs_backend__iterator_free;
 
+	/* Loose refs must be read before reloading the packed refs to
+	 * avoid a race condition in which loose refs are being packed
+	 * by another process.
+	 */
 	if (iter_load_loose_paths(backend, iter) < 0)
 		goto fail;
+
+	if (packed_reload(backend) < 0)
+		goto fail;
+
+	iter_shadow_packed_refs(backend, iter);
 
 	*out = (git_reference_iterator *)iter;
 	return 0;


### PR DESCRIPTION

When refs are packed, a new pack file is created containing all previously
packed refs as well as any newly packed loose refs. The existing pack file is
then replaced by the new pack file, and any included loose refs are deleted.

In order to avoid a race condition when another process is packing refs, the
loose refs must be loaded before the pack file is loaded.

The bug can be demonstrated in the current code by placing a sleep after the
call to packed_reload and packing the refs in another process. As a result,
any refs that were transitioning from loose to packed will be omited from the
list of refs returned by the iterator.